### PR TITLE
update plugin to require a newer jenkins version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+# Features
+- Use publishers as a Build Step (via the Conditional BuildStep Plugin)
+- Use builders during the Post-build Actions (via the Flexible Publish Plugin)
+- Adds a global configuration option for the Flexible Publish and Conditional BuildStep Plugins to enable all build steps to be made available to them.

--- a/pom.xml
+++ b/pom.xml
@@ -97,28 +97,21 @@
     
     <issueManagement>
         <system>JIRA</system>
-        <url>http://issues.jenkins-ci.org/</url>
+        <url>https://issues.jenkins.io</url>
     </issueManagement>
     
-    <distributionManagement>
-        <repository>
-            <id>maven.jenkins-ci.org</id>
-            <url>http://maven.jenkins-ci.org:8081/content/repositories/releases/</url>
-        </repository>
-    </distributionManagement>
-        
 
     <repositories>
         <repository>
             <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
+            <url>https://repo.jenkins-ci.org/public/</url>
         </repository>
     </repositories>
 
     <pluginRepositories>
         <pluginRepository>
             <id>repo.jenkins-ci.org</id>
-            <url>http://repo.jenkins-ci.org/public/</url>
+            <url>https://repo.jenkins-ci.org/public/</url>
         </pluginRepository>
     </pluginRepositories>
 </project>  

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.408</version>
+        <version>4.51</version>
     </parent>
 
     <artifactId>any-buildstep</artifactId>
@@ -37,10 +37,11 @@
     <name>Any Build Step Plugin</name>
     <version>0.2-SNAPSHOT</version>
     <description>Use publishers as builders and builders as publishers :-/</description>
-    <url>http://wiki.jenkins-ci.org/display/JENKINS/Any+Build+Step+Plugin</url>
+    <url>https://github.com/jenkinsci/any-buildstep-plugin</url>
 
     <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <jenkins.version>2.289.3</jenkins.version>
+        <gitHubRepo>jenkinsci/any-buildstep-plugin</gitHubRepo>
     </properties>
     
     <licenses>
@@ -58,23 +59,40 @@
         </developer>
     </developers>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.jenkins.tools.bom</groupId>
+                <artifactId>bom-2.289.x</artifactId>
+                <version>1500.ve4d05cd32975</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>flexible-publish</artifactId>
-            <version>0.8-SNAPSHOT</version>
+            <version>0.16.1</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>conditional-buildstep</artifactId>
-            <version>0.3-SNAPSHOT</version>
+            <version>1.4.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>run-condition</artifactId>
+            <version>1.5</version>
         </dependency>
     </dependencies>
 
     <scm>
-        <url>https://github.com/jenkinsci/any-buildstep-plugin</url>
-        <connection>scm:git:git://github.com/jenkinsci/any-buildstep-plugin.git</connection>
-        <developerConnection>scm:git:git@github.com:jenkinsci/any-buildstep-plugin.git</developerConnection>
+        <connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
+        <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
+        <url>https://github.com/${gitHubRepo}</url>
     </scm>
     
     <issueManagement>

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,3 +1,5 @@
+<?jelly escape-by-default='true'?>
+
 <!--
   ~ The MIT License
   ~


### PR DESCRIPTION
so that the plugin no longer implicitly depends on the WMI windows agents plugin
Add a README

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
